### PR TITLE
fix routes in generator put.php.twig

### DIFF
--- a/templates/generator/api/put.php.twig
+++ b/templates/generator/api/put.php.twig
@@ -40,8 +40,6 @@ final class Put extends AbstractFOSRestController
     }
 
     /**
-     * @Rest\Put("/{{ entityPluralDash }}/{id}", name=Put::class)
-     *
      * @OA\Tag(name="{{ entityHumanize }}")
      * @OA\RequestBody(
      *     content={


### PR DESCRIPTION
fix error

[Semantical Error] The annotation "@Rest\Put" in method KejawenLab\Application\Controller\Todo\Put::__invoke() was never imported. Did you maybe forget to add a "use" statement for this annotation? in /semart/config/routes/../../app/Controller/ (which is being imported from "/semart/config/routes/annotations.yaml"). Make sure there is a loader supporting the "annotation" type.  